### PR TITLE
Update getAlbums method in index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -94,7 +94,7 @@ class CameraRollRNPhotosFramework {
 
   getAlbums(params) {
     return this
-      .getAlbumsMany(params)
+      .getAlbumsMany([params])
       .then((queryResults) => {
         return queryResults[0];
       });


### PR DESCRIPTION
According to the documentation, the parameter of the getAlbums() method should be provided as an object in order to work; not an array.  I modified the getAlbums() method to send the params object within an array to the getAlbumsMany() method.  I've tested the change and all is working as expected.