### PR TITLE
Adding reverse option

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ import RNPhotosFramework from 'react-native-photos-framework';
 | includeMetaData | false | `boolean` | Include a lot of meta data about the asset (See below). You can also choose to get this metaData at a later point by calling asset.getMetaData (See below) |
 | prepareForSizeDisplay | - | `Rect(width, height)` | The size of the image you soon will display after running the query. This is highly optional and only there for optimizations of big lists. Prepares the images for display in Photos by using PHCachingImageManager |
 | prepareScale | 2.0 | `number` | The scale to prepare the image in. |
+| assetDisplayStartToEnd | false | `boolean` | Retrieves assets from the beginning of the library when set to true. Using this sorting option preserves the native order of assets as they are viewed in the Photos app.  |
+| assetDisplayBottomUp | false | `boolean` | Used to arrange assets from the bottom to top of screen when scrolling up to view paginated results. |
 
 ###Example of asset response with `includeMetaData : true`
 ~~~~

--- a/example/react-native-camera-roll-picker/camera-roll-picker.js
+++ b/example/react-native-camera-roll-picker/camera-roll-picker.js
@@ -84,16 +84,9 @@ class CameraRollPicker extends Component {
         trackInsertsAndDeletes : true,
         trackAssetsChanges : true,
         startIndex: this.state.images.length,
-        endIndex: this.state.images.length + 200,
-        fetchOptions: {
-          includeHiddenAssets : true,
-          sortDescriptors: [
-            {
-              key: 'creationDate',
-              ascending: false
-            }
-          ]
-        }
+        endIndex: this.state.images.length + 20,
+        fetchOptions: {},
+        reverse : true
 
       }, true)
       .then((data) => {

--- a/ios/RNPhotosFramework.xcodeproj/project.pbxproj
+++ b/ios/RNPhotosFramework.xcodeproj/project.pbxproj
@@ -415,6 +415,7 @@
 					"$(SRCROOT)/../../react-native/React/**",
 					"$(SRCROOT)/../../react-native/Libraries/Image",
 					"$(SRCROOT)/../example/node_modules/react-native/React/**",
+					"$(SRCROOT)/../example/node_modules/react-native/Libraries/Image",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -432,6 +433,7 @@
 					"$(SRCROOT)/../../react-native/React/**",
 					"$(SRCROOT)/../../react-native/Libraries/Image",
 					"$(SRCROOT)/../example/node_modules/react-native/React/**",
+					"$(SRCROOT)/../example/node_modules/react-native/Libraries/Image",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/ios/RNPhotosFramework.xcodeproj/project.pbxproj
+++ b/ios/RNPhotosFramework.xcodeproj/project.pbxproj
@@ -414,6 +414,7 @@
 					"$(SRCROOT)/../../gotlandskartan/app/node_modules/react-native/Libraries/Image",
 					"$(SRCROOT)/../../react-native/React/**",
 					"$(SRCROOT)/../../react-native/Libraries/Image",
+					"$(SRCROOT)/../example/node_modules/react-native/React/**",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -430,6 +431,7 @@
 					"$(SRCROOT)/../../gotlandskartan/app/node_modules/react-native/Libraries/Image",
 					"$(SRCROOT)/../../react-native/React/**",
 					"$(SRCROOT)/../../react-native/Libraries/Image",
+					"$(SRCROOT)/../example/node_modules/react-native/React/**",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/ios/RNPhotosFramework.xcodeproj/project.pbxproj
+++ b/ios/RNPhotosFramework.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		632D5ED31DF19458006A862C /* PHAssetsService_getAssetsForFetchResultTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 632D5ED21DF19458006A862C /* PHAssetsService_getAssetsForFetchResultTests.m */; };
+		632D5ED51DF19458006A862C /* libRNPhotosFramework.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 632F8C131DB758E7007E83E1 /* libRNPhotosFramework.a */; };
+		632D5EDD1DF19526006A862C /* libReact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 632D5EDC1DF19526006A862C /* libReact.a */; };
 		632F8C251DB75A4A007E83E1 /* PHCachingImageManagerInstance.m in Sources */ = {isa = PBXBuildFile; fileRef = 632F8C201DB75A4A007E83E1 /* PHCachingImageManagerInstance.m */; };
 		632F8C261DB75A4A007E83E1 /* RCTCameraRollRNPhotosFrameworkManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 632F8C221DB75A4A007E83E1 /* RCTCameraRollRNPhotosFrameworkManager.m */; };
 		632F8C271DB75A4A007E83E1 /* RCTImageLoaderRNPhotosFramework.m in Sources */ = {isa = PBXBuildFile; fileRef = 632F8C241DB75A4A007E83E1 /* RCTImageLoaderRNPhotosFramework.m */; };
@@ -19,6 +22,16 @@
 		63A33AB11DBEA06C0022B5FF /* PHCollectionService.m in Sources */ = {isa = PBXBuildFile; fileRef = 63A33AB01DBEA06C0022B5FF /* PHCollectionService.m */; };
 		63C543481DC00BDA004BFE57 /* PHHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 63C543471DC00BDA004BFE57 /* PHHelpers.m */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		632D5ED61DF19458006A862C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 632F8C0B1DB758E6007E83E1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 632F8C121DB758E6007E83E1;
+			remoteInfo = RNPhotosFramework;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
 		632F8C111DB758E6007E83E1 /* CopyFiles */ = {
@@ -33,6 +46,10 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		632D5ED01DF19458006A862C /* RNPhotosFrameworkTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RNPhotosFrameworkTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		632D5ED21DF19458006A862C /* PHAssetsService_getAssetsForFetchResultTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PHAssetsService_getAssetsForFetchResultTests.m; sourceTree = "<group>"; };
+		632D5ED41DF19458006A862C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		632D5EDC1DF19526006A862C /* libReact.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libReact.a; path = "../node_modules/react-native/React/build/Debug-iphoneos/libReact.a"; sourceTree = "<group>"; };
 		632F8C131DB758E7007E83E1 /* libRNPhotosFramework.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRNPhotosFramework.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		632F8C1F1DB75A4A007E83E1 /* PHCachingImageManagerInstance.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PHCachingImageManagerInstance.h; sourceTree = "<group>"; };
 		632F8C201DB75A4A007E83E1 /* PHCachingImageManagerInstance.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PHCachingImageManagerInstance.m; sourceTree = "<group>"; };
@@ -59,6 +76,15 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		632D5ECD1DF19458006A862C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				632D5EDD1DF19526006A862C /* libReact.a in Frameworks */,
+				632D5ED51DF19458006A862C /* libRNPhotosFramework.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		632F8C101DB758E6007E83E1 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -69,11 +95,30 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		632D5ED11DF19458006A862C /* RNPhotosFrameworkTests */ = {
+			isa = PBXGroup;
+			children = (
+				632D5ED21DF19458006A862C /* PHAssetsService_getAssetsForFetchResultTests.m */,
+				632D5ED41DF19458006A862C /* Info.plist */,
+			);
+			path = RNPhotosFrameworkTests;
+			sourceTree = "<group>";
+		};
+		632D5EDB1DF19525006A862C /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				632D5EDC1DF19526006A862C /* libReact.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		632F8C0A1DB758E6007E83E1 = {
 			isa = PBXGroup;
 			children = (
 				632F8C151DB758E7007E83E1 /* RNPhotosFramework */,
+				632D5ED11DF19458006A862C /* RNPhotosFrameworkTests */,
 				632F8C141DB758E7007E83E1 /* Products */,
+				632D5EDB1DF19525006A862C /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -81,6 +126,7 @@
 			isa = PBXGroup;
 			children = (
 				632F8C131DB758E7007E83E1 /* libRNPhotosFramework.a */,
+				632D5ED01DF19458006A862C /* RNPhotosFrameworkTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -117,6 +163,24 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		632D5ECF1DF19458006A862C /* RNPhotosFrameworkTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 632D5EDA1DF19458006A862C /* Build configuration list for PBXNativeTarget "RNPhotosFrameworkTests" */;
+			buildPhases = (
+				632D5ECC1DF19458006A862C /* Sources */,
+				632D5ECD1DF19458006A862C /* Frameworks */,
+				632D5ECE1DF19458006A862C /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				632D5ED71DF19458006A862C /* PBXTargetDependency */,
+			);
+			name = RNPhotosFrameworkTests;
+			productName = RNPhotosFrameworkTests;
+			productReference = 632D5ED01DF19458006A862C /* RNPhotosFrameworkTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		632F8C121DB758E6007E83E1 /* RNPhotosFramework */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 632F8C1C1DB758E7007E83E1 /* Build configuration list for PBXNativeTarget "RNPhotosFramework" */;
@@ -143,6 +207,11 @@
 				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = "Olof Dahlbom";
 				TargetAttributes = {
+					632D5ECF1DF19458006A862C = {
+						CreatedOnToolsVersion = 8.1;
+						DevelopmentTeam = 5BEG6QJ94B;
+						ProvisioningStyle = Automatic;
+					};
 					632F8C121DB758E6007E83E1 = {
 						CreatedOnToolsVersion = 8.0;
 						DevelopmentTeam = 5BEG6QJ94B;
@@ -163,11 +232,30 @@
 			projectRoot = "";
 			targets = (
 				632F8C121DB758E6007E83E1 /* RNPhotosFramework */,
+				632D5ECF1DF19458006A862C /* RNPhotosFrameworkTests */,
 			);
 		};
 /* End PBXProject section */
 
+/* Begin PBXResourcesBuildPhase section */
+		632D5ECE1DF19458006A862C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
 /* Begin PBXSourcesBuildPhase section */
+		632D5ECC1DF19458006A862C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				632D5ED31DF19458006A862C /* PHAssetsService_getAssetsForFetchResultTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		632F8C0F1DB758E6007E83E1 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -188,7 +276,47 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		632D5ED71DF19458006A862C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 632F8C121DB758E6007E83E1 /* RNPhotosFramework */;
+			targetProxy = 632D5ED61DF19458006A862C /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin XCBuildConfiguration section */
+		632D5ED81DF19458006A862C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEVELOPMENT_TEAM = 5BEG6QJ94B;
+				INFOPLIST_FILE = RNPhotosFrameworkTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.1;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.olof.dahlbom.RNPhotosFrameworkTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		632D5ED91DF19458006A862C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEVELOPMENT_TEAM = 5BEG6QJ94B;
+				INFOPLIST_FILE = RNPhotosFrameworkTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.1;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.olof.dahlbom.RNPhotosFrameworkTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
 		632F8C1A1DB758E7007E83E1 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -312,6 +440,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		632D5EDA1DF19458006A862C /* Build configuration list for PBXNativeTarget "RNPhotosFrameworkTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				632D5ED81DF19458006A862C /* Debug */,
+				632D5ED91DF19458006A862C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		632F8C0E1DB758E6007E83E1 /* Build configuration list for PBXProject "RNPhotosFramework" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/ios/RNPhotosFramework.xcworkspace/contents.xcworkspacedata
+++ b/ios/RNPhotosFramework.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:../example/node_modules/react-native/React/React.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:RNPhotosFramework.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/ios/RNPhotosFramework/PHAssetsService.h
+++ b/ios/RNPhotosFramework/PHAssetsService.h
@@ -3,7 +3,7 @@
 @interface PHAssetsService : NSObject
 +(PHFetchResult<PHAsset *> *) getAssetsForParams:(NSDictionary *)params;
 +(NSArray<NSDictionary *> *) assetsArrayToUriArray:(NSArray<PHAsset *> *)assetsArray andIncludeMetaData:(BOOL)includeMetaData;
-+(NSMutableArray<PHAsset *> *) getAssetsForFetchResult:(PHFetchResult *)assetsFetchResult startIndex:(int)startIndex endIndex:(int)endIndex andReverseIndices:(BOOL)reverseIndices;
++(NSMutableArray<PHAsset *> *) getAssetsForFetchResult:(PHFetchResult *)assetsFetchResult startIndex:(int)startIndex endIndex:(int)endIndex assetDisplayStartToEnd:(BOOL)assetDisplayStartToEnd andAssetDisplayTopDown:(BOOL)assetDisplayTopDown;
 +(PHFetchResult<PHAsset *> *) getAssetsFromArrayOfLocalIdentifiers:(NSArray<NSString *> *)arrayWithLocalIdentifiers;
 +(NSMutableDictionary *)extendAssetDicWithAssetMetaData:(NSMutableDictionary *)dictToExtend andPHAsset:(PHAsset *)asset;
 +(void)deleteAssets:(NSArray<PHAsset *> *)assetsToDelete andCompleteBLock:(nullable void(^)(BOOL success, NSError *__nullable error, NSArray<NSString *> * localIdentifiers))completeBlock;

--- a/ios/RNPhotosFramework/PHAssetsService.h
+++ b/ios/RNPhotosFramework/PHAssetsService.h
@@ -3,7 +3,7 @@
 @interface PHAssetsService : NSObject
 +(PHFetchResult<PHAsset *> *) getAssetsForParams:(NSDictionary *)params;
 +(NSArray<NSDictionary *> *) assetsArrayToUriArray:(NSArray<PHAsset *> *)assetsArray andIncludeMetaData:(BOOL)includeMetaData;
-+(NSMutableArray<PHAsset *> *) getAssetsForFetchResult:(PHFetchResult *)assetsFetchResult startIndex:(NSUInteger)startIndex endIndex:(NSUInteger)endIndex;
++(NSMutableArray<PHAsset *> *) getAssetsForFetchResult:(PHFetchResult *)assetsFetchResult startIndex:(int)startIndex endIndex:(int)endIndex andReverseIndices:(BOOL)reverseIndices;
 +(PHFetchResult<PHAsset *> *) getAssetsFromArrayOfLocalIdentifiers:(NSArray<NSString *> *)arrayWithLocalIdentifiers;
 +(NSMutableDictionary *)extendAssetDicWithAssetMetaData:(NSMutableDictionary *)dictToExtend andPHAsset:(PHAsset *)asset;
 +(void)deleteAssets:(NSArray<PHAsset *> *)assetsToDelete andCompleteBLock:(nullable void(^)(BOOL success, NSError *__nullable error, NSArray<NSString *> * localIdentifiers))completeBlock;

--- a/ios/RNPhotosFramework/PHAssetsService.h
+++ b/ios/RNPhotosFramework/PHAssetsService.h
@@ -3,7 +3,7 @@
 @interface PHAssetsService : NSObject
 +(PHFetchResult<PHAsset *> *) getAssetsForParams:(NSDictionary *)params;
 +(NSArray<NSDictionary *> *) assetsArrayToUriArray:(NSArray<PHAsset *> *)assetsArray andIncludeMetaData:(BOOL)includeMetaData;
-+(NSMutableArray<PHAsset *> *) getAssetsForFetchResult:(PHFetchResult *)assetsFetchResult startIndex:(int)startIndex endIndex:(int)endIndex assetDisplayStartToEnd:(BOOL)assetDisplayStartToEnd andAssetDisplayTopDown:(BOOL)assetDisplayTopDown;
++(NSMutableArray<PHAsset *> *) getAssetsForFetchResult:(PHFetchResult *)assetsFetchResult startIndex:(int)startIndex endIndex:(int)endIndex assetDisplayStartToEnd:(BOOL)assetDisplayStartToEnd andAssetDisplayBottomUp:(BOOL)assetDisplayBottomUp;
 +(PHFetchResult<PHAsset *> *) getAssetsFromArrayOfLocalIdentifiers:(NSArray<NSString *> *)arrayWithLocalIdentifiers;
 +(NSMutableDictionary *)extendAssetDicWithAssetMetaData:(NSMutableDictionary *)dictToExtend andPHAsset:(PHAsset *)asset;
 +(void)deleteAssets:(NSArray<PHAsset *> *)assetsToDelete andCompleteBLock:(nullable void(^)(BOOL success, NSError *__nullable error, NSArray<NSString *> * localIdentifiers))completeBlock;

--- a/ios/RNPhotosFramework/PHAssetsService.m
+++ b/ios/RNPhotosFramework/PHAssetsService.m
@@ -120,7 +120,7 @@
         }
         NSIndexSet *indexSet = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(startIndex, endIndex - startIndex)];
         // display assets from the bottom to top of page if assetDisplayBottomUp is true
-        NSEnumerationOptions enumerationOptions = assetDisplayBottomUp ? NSEnumerationReverse : NSEnumerationConcurrent;
+        NSEnumerationOptions enumerationOptions = assetDisplayBottomUp ? NSEnumerationConcurrent : NSEnumerationReverse;
         [assetsFetchResult enumerateObjectsAtIndexes:indexSet options:enumerationOptions usingBlock:^(PHAsset *asset, NSUInteger idx, BOOL * _Nonnull stop) {
             [assets addObject:asset];
         }];

--- a/ios/RNPhotosFramework/PHAssetsService.m
+++ b/ios/RNPhotosFramework/PHAssetsService.m
@@ -93,20 +93,16 @@
     return dictToExtend;
 }
 
-+(NSMutableArray<PHAsset *> *) getAssetsForFetchResult:(PHFetchResult *)assetsFetchResult startIndex:(int)startIndex endIndex:(int)endIndex andReverseIndices:(BOOL)reverseIndices {
-    
++(NSMutableArray<PHAsset *> *) getAssetsForFetchResult:(PHFetchResult *)assetsFetchResult startIndex:(int)startIndex endIndex:(int)endIndex assetDisplayStartToEnd:(BOOL)assetDisplayStartToEnd andAssetDisplayTopDown:(BOOL)assetDisplayTopDown {
     NSMutableArray<PHAsset *> *assets = [NSMutableArray new];
     int assetCount = assetsFetchResult.count;
     if(assetCount != 0) {
         int originalStartIndex = startIndex;
         int originalEndIndex = endIndex;
-
-        // load most recent assets from library first by default
         startIndex = (assetCount - endIndex) - 1;
         endIndex = assetCount - originalStartIndex;
-        
-        // load oldest assets from library first if reverseIndices is true
-        if(reverseIndices) {
+        // load oldest assets from library first if assetDisplayStartToEnd is true
+        if(assetDisplayStartToEnd) {
             startIndex = originalStartIndex;
             endIndex = originalEndIndex;
         }
@@ -123,7 +119,8 @@
             endIndex = assetCount;
         }
         NSIndexSet *indexSet = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(startIndex, endIndex - startIndex)];
-        NSEnumerationOptions enumerationOptions = reverseIndices ? NSEnumerationConcurrent : NSEnumerationReverse;
+        // display assets from the top to bottom of page if assetDisplayTopDown is true
+        NSEnumerationOptions enumerationOptions = assetDisplayTopDown ? NSEnumerationConcurrent : NSEnumerationReverse;
         [assetsFetchResult enumerateObjectsAtIndexes:indexSet options:enumerationOptions usingBlock:^(PHAsset *asset, NSUInteger idx, BOOL * _Nonnull stop) {
             [assets addObject:asset];
         }];

--- a/ios/RNPhotosFramework/PHAssetsService.m
+++ b/ios/RNPhotosFramework/PHAssetsService.m
@@ -100,7 +100,7 @@
     if(assetCount != 0) {
         if(reverseIndices) {
             int originalStartIndex = startIndex;
-            startIndex = assetCount - endIndex;
+            startIndex = (assetCount - endIndex) - 1;
             endIndex = assetCount - originalStartIndex;
         }
         if(startIndex < 0) {
@@ -110,10 +110,10 @@
             endIndex = 0;
         }
         if(startIndex >= assetCount) {
-            startIndex = assetCount -1;
+            startIndex = assetCount;
         }
         if(endIndex >= assetCount) {
-            endIndex = assetCount -1;
+            endIndex = assetCount;
         }
         NSIndexSet *indexSet = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(startIndex, endIndex - startIndex)];
         NSEnumerationOptions enumerationOptions = reverseIndices ? NSEnumerationConcurrent : NSEnumerationReverse;

--- a/ios/RNPhotosFramework/PHAssetsService.m
+++ b/ios/RNPhotosFramework/PHAssetsService.m
@@ -116,7 +116,7 @@
             endIndex = assetCount;
         }
         NSIndexSet *indexSet = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(startIndex, endIndex - startIndex)];
-        NSEnumerationOptions enumerationOptions = reverseIndices ? NSEnumerationConcurrent : NSEnumerationReverse;
+        NSEnumerationOptions enumerationOptions = reverseIndices ? NSEnumerationReverse : NSEnumerationConcurrent;
         [assetsFetchResult enumerateObjectsAtIndexes:indexSet options:enumerationOptions usingBlock:^(PHAsset *asset, NSUInteger idx, BOOL * _Nonnull stop) {
             [assets addObject:asset];
         }];

--- a/ios/RNPhotosFramework/PHAssetsService.m
+++ b/ios/RNPhotosFramework/PHAssetsService.m
@@ -98,10 +98,17 @@
     NSMutableArray<PHAsset *> *assets = [NSMutableArray new];
     int assetCount = assetsFetchResult.count;
     if(assetCount != 0) {
+        int originalStartIndex = startIndex;
+        int originalEndIndex = endIndex;
+
+        // load most recent assets from library first by default
+        startIndex = (assetCount - endIndex) - 1;
+        endIndex = assetCount - originalStartIndex;
+        
+        // load oldest assets from library first if reverseIndices is true
         if(reverseIndices) {
-            int originalStartIndex = startIndex;
-            startIndex = (assetCount - endIndex) - 1;
-            endIndex = assetCount - originalStartIndex;
+            startIndex = originalStartIndex;
+            endIndex = originalEndIndex;
         }
         if(startIndex < 0) {
             startIndex = 0;
@@ -116,7 +123,7 @@
             endIndex = assetCount;
         }
         NSIndexSet *indexSet = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(startIndex, endIndex - startIndex)];
-        NSEnumerationOptions enumerationOptions = reverseIndices ? NSEnumerationReverse : NSEnumerationConcurrent;
+        NSEnumerationOptions enumerationOptions = reverseIndices ? NSEnumerationConcurrent : NSEnumerationReverse;
         [assetsFetchResult enumerateObjectsAtIndexes:indexSet options:enumerationOptions usingBlock:^(PHAsset *asset, NSUInteger idx, BOOL * _Nonnull stop) {
             [assets addObject:asset];
         }];

--- a/ios/RNPhotosFramework/PHAssetsService.m
+++ b/ios/RNPhotosFramework/PHAssetsService.m
@@ -119,7 +119,7 @@
             endIndex = assetCount;
         }
         NSIndexSet *indexSet = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(startIndex, endIndex - startIndex)];
-        // display assets from the top to bottom of page if assetDisplayBottomUp is true
+        // display assets from the bottom to top of page if assetDisplayBottomUp is true
         NSEnumerationOptions enumerationOptions = assetDisplayBottomUp ? NSEnumerationReverse : NSEnumerationConcurrent;
         [assetsFetchResult enumerateObjectsAtIndexes:indexSet options:enumerationOptions usingBlock:^(PHAsset *asset, NSUInteger idx, BOOL * _Nonnull stop) {
             [assets addObject:asset];

--- a/ios/RNPhotosFramework/PHAssetsService.m
+++ b/ios/RNPhotosFramework/PHAssetsService.m
@@ -93,7 +93,7 @@
     return dictToExtend;
 }
 
-+(NSMutableArray<PHAsset *> *) getAssetsForFetchResult:(PHFetchResult *)assetsFetchResult startIndex:(int)startIndex endIndex:(int)endIndex assetDisplayStartToEnd:(BOOL)assetDisplayStartToEnd andAssetDisplayTopDown:(BOOL)assetDisplayTopDown {
++(NSMutableArray<PHAsset *> *) getAssetsForFetchResult:(PHFetchResult *)assetsFetchResult startIndex:(int)startIndex endIndex:(int)endIndex assetDisplayStartToEnd:(BOOL)assetDisplayStartToEnd andAssetDisplayBottomUp:(BOOL)assetDisplayBottomUp {
     NSMutableArray<PHAsset *> *assets = [NSMutableArray new];
     int assetCount = assetsFetchResult.count;
     if(assetCount != 0) {
@@ -119,8 +119,8 @@
             endIndex = assetCount;
         }
         NSIndexSet *indexSet = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(startIndex, endIndex - startIndex)];
-        // display assets from the top to bottom of page if assetDisplayTopDown is true
-        NSEnumerationOptions enumerationOptions = assetDisplayTopDown ? NSEnumerationConcurrent : NSEnumerationReverse;
+        // display assets from the top to bottom of page if assetDisplayBottomUp is true
+        NSEnumerationOptions enumerationOptions = assetDisplayBottomUp ? NSEnumerationReverse : NSEnumerationConcurrent;
         [assetsFetchResult enumerateObjectsAtIndexes:indexSet options:enumerationOptions usingBlock:^(PHAsset *asset, NSUInteger idx, BOOL * _Nonnull stop) {
             [assets addObject:asset];
         }];

--- a/ios/RNPhotosFramework/PHAssetsService.m
+++ b/ios/RNPhotosFramework/PHAssetsService.m
@@ -93,19 +93,35 @@
     return dictToExtend;
 }
 
-+(NSMutableArray<PHAsset *> *) getAssetsForFetchResult:(PHFetchResult *)assetsFetchResult startIndex:(NSUInteger)startIndex endIndex:(NSUInteger)endIndex {
++(NSMutableArray<PHAsset *> *) getAssetsForFetchResult:(PHFetchResult *)assetsFetchResult startIndex:(int)startIndex endIndex:(int)endIndex andReverseIndices:(BOOL)reverseIndices {
     
     NSMutableArray<PHAsset *> *assets = [NSMutableArray new];
-    [assetsFetchResult enumerateObjectsUsingBlock:^(PHAsset *asset, NSUInteger index, BOOL *stop) {
-        if(index >= startIndex){
+    int assetCount = assetsFetchResult.count;
+    if(assetCount != 0) {
+        if(reverseIndices) {
+            int originalStartIndex = startIndex;
+            startIndex = assetCount - endIndex;
+            endIndex = assetCount - originalStartIndex;
+        }
+        if(startIndex < 0) {
+            startIndex = 0;
+        }
+        if(endIndex < 0) {
+            endIndex = 0;
+        }
+        if(startIndex >= assetCount) {
+            startIndex = assetCount -1;
+        }
+        if(endIndex >= assetCount) {
+            endIndex = assetCount -1;
+        }
+        NSIndexSet *indexSet = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(startIndex, endIndex - startIndex)];
+        NSEnumerationOptions enumerationOptions = reverseIndices ? NSEnumerationConcurrent : NSEnumerationReverse;
+        [assetsFetchResult enumerateObjectsAtIndexes:indexSet options:enumerationOptions usingBlock:^(PHAsset *asset, NSUInteger idx, BOOL * _Nonnull stop) {
             [assets addObject:asset];
-        }
-        if(index >= endIndex){
-            *stop = YES;
-            return;
-        }
-        
-    }];
+        }];
+    }
+
     return assets;
 }
 

--- a/ios/RNPhotosFramework/PHCollectionService.m
+++ b/ios/RNPhotosFramework/PHCollectionService.m
@@ -170,7 +170,8 @@ static id ObjectOrNull(id object)
                 }
                 
                 if(numberOfPreviewAssets > 0) {
-                   NSArray<NSDictionary *> *previewAssets = [PHAssetsService assetsArrayToUriArray:[PHAssetsService getAssetsForFetchResult:assets startIndex:0 endIndex:(numberOfPreviewAssets-1)] andIncludeMetaData:NO];
+                   BOOL reverseIndices = [RCTConvert BOOL:assetFetchParams[@"reverse"]];
+                   NSArray<NSDictionary *> *previewAssets = [PHAssetsService assetsArrayToUriArray:[PHAssetsService getAssetsForFetchResult:assets startIndex:0 endIndex:(numberOfPreviewAssets-1) andReverseIndices:reverseIndices] andIncludeMetaData:NO];
                     [albumDictionary setObject:previewAssets forKey:@"previewAssets"];
                 }
                 

--- a/ios/RNPhotosFramework/PHCollectionService.m
+++ b/ios/RNPhotosFramework/PHCollectionService.m
@@ -170,8 +170,9 @@ static id ObjectOrNull(id object)
                 }
                 
                 if(numberOfPreviewAssets > 0) {
-                   BOOL reverseIndices = [RCTConvert BOOL:assetFetchParams[@"reverse"]];
-                   NSArray<NSDictionary *> *previewAssets = [PHAssetsService assetsArrayToUriArray:[PHAssetsService getAssetsForFetchResult:assets startIndex:0 endIndex:(numberOfPreviewAssets-1) andReverseIndices:reverseIndices] andIncludeMetaData:NO];
+                    BOOL assetDisplayStartToEnd = [RCTConvert BOOL:assetFetchParams[@"assetDisplayStartToEnd"]];
+                    BOOL assetDisplayTopDown = [RCTConvert BOOL:assetFetchParams[@"assetDisplayTopDown"]];
+                    NSArray<NSDictionary *> *previewAssets = [PHAssetsService assetsArrayToUriArray:[PHAssetsService getAssetsForFetchResult:assets startIndex:0 endIndex:(numberOfPreviewAssets-1) assetDisplayStartToEnd:assetDisplayStartToEnd andAssetDisplayTopDown:assetDisplayTopDown] andIncludeMetaData:NO];
                     [albumDictionary setObject:previewAssets forKey:@"previewAssets"];
                 }
                 

--- a/ios/RNPhotosFramework/PHCollectionService.m
+++ b/ios/RNPhotosFramework/PHCollectionService.m
@@ -171,8 +171,8 @@ static id ObjectOrNull(id object)
                 
                 if(numberOfPreviewAssets > 0) {
                     BOOL assetDisplayStartToEnd = [RCTConvert BOOL:assetFetchParams[@"assetDisplayStartToEnd"]];
-                    BOOL assetDisplayTopDown = [RCTConvert BOOL:assetFetchParams[@"assetDisplayTopDown"]];
-                    NSArray<NSDictionary *> *previewAssets = [PHAssetsService assetsArrayToUriArray:[PHAssetsService getAssetsForFetchResult:assets startIndex:0 endIndex:(numberOfPreviewAssets-1) assetDisplayStartToEnd:assetDisplayStartToEnd andAssetDisplayTopDown:assetDisplayTopDown] andIncludeMetaData:NO];
+                    BOOL assetDisplayBottomUp = [RCTConvert BOOL:assetFetchParams[@"assetDisplayBottomUp"]];
+                    NSArray<NSDictionary *> *previewAssets = [PHAssetsService assetsArrayToUriArray:[PHAssetsService getAssetsForFetchResult:assets startIndex:0 endIndex:(numberOfPreviewAssets-1) assetDisplayStartToEnd:assetDisplayStartToEnd andAssetDisplayBottomUp:assetDisplayBottomUp] andIncludeMetaData:NO];
                     [albumDictionary setObject:previewAssets forKey:@"previewAssets"];
                 }
                 

--- a/ios/RNPhotosFramework/PHFetchOptionsService.m
+++ b/ios/RNPhotosFramework/PHFetchOptionsService.m
@@ -26,9 +26,6 @@
     NSDictionary *params = [RCTConvert NSDictionary:outerParams[@"fetchOptions"]];
     PHFetchOptions *options = [[PHFetchOptions alloc] init];
     options = [self getCommonFetchOptionsFromParams:params andFetchOptions:options];
-    if(options.sortDescriptors == nil || options.sortDescriptors.count == 0) {
-        options.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"creationDate" ascending:NO]];
-    }
     return options;
 }
 

--- a/ios/RNPhotosFramework/RCTCameraRollRNPhotosFrameworkManager.m
+++ b/ios/RNPhotosFramework/RCTCameraRollRNPhotosFrameworkManager.m
@@ -68,10 +68,11 @@ RCT_EXPORT_METHOD(getAssets:(NSDictionary *)params
     NSString *endIndexParam = params[@"endIndex"];
     BOOL includeMetaData = [RCTConvert BOOL:params[@"includeMetaData"]];
     
-    NSUInteger startIndex = [RCTConvert NSInteger:startIndexParam];
-    NSUInteger endIndex = endIndexParam != nil ? [RCTConvert NSInteger:endIndexParam] : (assetsFetchResult.count -1);
+    int startIndex = [RCTConvert int:startIndexParam];
+    int endIndex = endIndexParam != nil ? [RCTConvert int:endIndexParam] : (assetsFetchResult.count -1);
     
-    NSArray<PHAsset *> *assets = [PHAssetsService getAssetsForFetchResult:assetsFetchResult startIndex:startIndex endIndex:endIndex];
+    BOOL reverseIndices = [RCTConvert BOOL:params[@"reverse"]];
+    NSArray<PHAsset *> *assets = [PHAssetsService getAssetsForFetchResult:assetsFetchResult startIndex:startIndex endIndex:endIndex andReverseIndices:reverseIndices];
     [self prepareAssetsForDisplayWithParams:params andAssets:assets];
     NSInteger assetCount = assetsFetchResult.count;
     BOOL includesLastAsset = assetCount == 0 || endIndex >= (assetCount -1);

--- a/ios/RNPhotosFramework/RCTCameraRollRNPhotosFrameworkManager.m
+++ b/ios/RNPhotosFramework/RCTCameraRollRNPhotosFrameworkManager.m
@@ -71,8 +71,9 @@ RCT_EXPORT_METHOD(getAssets:(NSDictionary *)params
     int startIndex = [RCTConvert int:startIndexParam];
     int endIndex = endIndexParam != nil ? [RCTConvert int:endIndexParam] : (assetsFetchResult.count -1);
     
-    BOOL reverseIndices = [RCTConvert BOOL:params[@"reverse"]];
-    NSArray<PHAsset *> *assets = [PHAssetsService getAssetsForFetchResult:assetsFetchResult startIndex:startIndex endIndex:endIndex andReverseIndices:reverseIndices];
+    BOOL assetDisplayStartToEnd = [RCTConvert BOOL:params[@"assetDisplayStartToEnd"]];
+    BOOL assetDisplayTopDown = [RCTConvert BOOL:params[@"assetDisplayTopDown"]];
+    NSArray<PHAsset *> *assets = [PHAssetsService getAssetsForFetchResult:assetsFetchResult startIndex:startIndex endIndex:endIndex assetDisplayStartToEnd:assetDisplayStartToEnd andAssetDisplayTopDown:assetDisplayTopDown];
     [self prepareAssetsForDisplayWithParams:params andAssets:assets];
     NSInteger assetCount = assetsFetchResult.count;
     BOOL includesLastAsset = assetCount == 0 || endIndex >= (assetCount -1);

--- a/ios/RNPhotosFramework/RCTCameraRollRNPhotosFrameworkManager.m
+++ b/ios/RNPhotosFramework/RCTCameraRollRNPhotosFrameworkManager.m
@@ -72,8 +72,8 @@ RCT_EXPORT_METHOD(getAssets:(NSDictionary *)params
     int endIndex = endIndexParam != nil ? [RCTConvert int:endIndexParam] : (assetsFetchResult.count -1);
     
     BOOL assetDisplayStartToEnd = [RCTConvert BOOL:params[@"assetDisplayStartToEnd"]];
-    BOOL assetDisplayTopDown = [RCTConvert BOOL:params[@"assetDisplayTopDown"]];
-    NSArray<PHAsset *> *assets = [PHAssetsService getAssetsForFetchResult:assetsFetchResult startIndex:startIndex endIndex:endIndex assetDisplayStartToEnd:assetDisplayStartToEnd andAssetDisplayTopDown:assetDisplayTopDown];
+    BOOL assetDisplayBottomUp = [RCTConvert BOOL:params[@"assetDisplayBottomUp"]];
+    NSArray<PHAsset *> *assets = [PHAssetsService getAssetsForFetchResult:assetsFetchResult startIndex:startIndex endIndex:endIndex assetDisplayStartToEnd:assetDisplayStartToEnd andAssetDisplayBottomUp:assetDisplayBottomUp];
     [self prepareAssetsForDisplayWithParams:params andAssets:assets];
     NSInteger assetCount = assetsFetchResult.count;
     BOOL includesLastAsset = assetCount == 0 || endIndex >= (assetCount -1);

--- a/ios/RNPhotosFrameworkTests/Info.plist
+++ b/ios/RNPhotosFrameworkTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/ios/RNPhotosFrameworkTests/PHAssetsService_getAssetsForFetchResultTests.m
+++ b/ios/RNPhotosFrameworkTests/PHAssetsService_getAssetsForFetchResultTests.m
@@ -1,0 +1,107 @@
+#pragma clang diagnostic ignored "-Wincompatible-pointer-types"
+
+#import <XCTest/XCTest.h>
+#import "PHAssetsService.h"
+
+@interface PHAssetsServicegetAssetsForFetchResultTests : XCTestCase
+@end
+
+@implementation PHAssetsServicegetAssetsForFetchResultTests
+NSMutableArray *arrayWithFakeAssets;
+NSMutableArray *scenarioAssets;
+
+
+- (void)setUp {
+    arrayWithFakeAssets = [NSMutableArray new];
+    for(int i = 0; i < 200;i++){
+        [arrayWithFakeAssets addObject:@(i)];
+    }
+    
+    scenarioAssets = [NSMutableArray new];
+    [scenarioAssets addObject:@(2012)];
+    [scenarioAssets addObject:@(2013)];
+    [scenarioAssets addObject:@(2014)];
+    [scenarioAssets addObject:@(2015)];
+    [scenarioAssets addObject:@(2016)];
+
+    [super setUp];
+}
+
+- (void)tearDown {
+    arrayWithFakeAssets = nil;
+    scenarioAssets = nil;
+    [super tearDown];
+}
+
+- (void)testShouldReturnEqualAmountOfAssets {
+    NSArray *resultYesYes = [PHAssetsService getAssetsForFetchResult:arrayWithFakeAssets startIndex:5 endIndex:15 assetDisplayStartToEnd:YES andAssetDisplayBottomUp:YES];
+    [self setUp];
+    NSArray *resultYesNo = [PHAssetsService getAssetsForFetchResult:arrayWithFakeAssets startIndex:5 endIndex:15 assetDisplayStartToEnd:YES andAssetDisplayBottomUp:NO];
+    [self setUp];
+    NSArray *resultNoYes = [PHAssetsService getAssetsForFetchResult:arrayWithFakeAssets startIndex:5 endIndex:15 assetDisplayStartToEnd:YES andAssetDisplayBottomUp:NO];
+    [self setUp];
+    NSArray *resultNoNo = [PHAssetsService getAssetsForFetchResult:arrayWithFakeAssets startIndex:5 endIndex:15 assetDisplayStartToEnd:YES andAssetDisplayBottomUp:NO];
+    XCTAssertTrue(resultYesYes.count == 10);
+    XCTAssertTrue(resultYesNo.count == 10);
+    XCTAssertTrue(resultNoYes.count == 10);
+    XCTAssertTrue(resultNoNo.count == 10);
+}
+
+//Testing scenarios from : https://github.com/olofd/react-native-photos-framework/pull/11#issuecomment-264324873
+-(void) testOrderScenarioOne {
+    NSArray <NSNumber *> *result = [PHAssetsService getAssetsForFetchResult:scenarioAssets startIndex:0 endIndex:2 assetDisplayStartToEnd:NO andAssetDisplayBottomUp:YES];
+    
+    XCTAssertEqual(result.count, 3);
+    XCTAssertEqual([result[0] intValue], 2016);
+    XCTAssertEqual([result[1] intValue], 2015);
+    XCTAssertEqual([result[2] intValue], 2014);
+    //scrolling down will load
+    result = [PHAssetsService getAssetsForFetchResult:scenarioAssets startIndex:3 endIndex:5 assetDisplayStartToEnd:NO andAssetDisplayBottomUp:YES];
+    XCTAssertEqual(result.count, 2);
+    XCTAssertEqual([result[0] intValue], 2013);
+    XCTAssertEqual([result[1] intValue], 2012);
+}
+
+-(void) testOrderScenarioTwo {
+    NSArray <NSNumber *> *result = [PHAssetsService getAssetsForFetchResult:scenarioAssets startIndex:0 endIndex:2 assetDisplayStartToEnd:YES andAssetDisplayBottomUp:YES];
+    
+    XCTAssertEqual(result.count, 3);
+    XCTAssertEqual([result[0] intValue], 2012);
+    XCTAssertEqual([result[1] intValue], 2013);
+    XCTAssertEqual([result[2] intValue], 2014);
+    //scrolling down will load
+    result = [PHAssetsService getAssetsForFetchResult:scenarioAssets startIndex:3 endIndex:5 assetDisplayStartToEnd:NO andAssetDisplayBottomUp:YES];
+    XCTAssertEqual(result.count, 2);
+    XCTAssertEqual([result[0] intValue], 2015);
+    XCTAssertEqual([result[1] intValue], 2016);
+}
+
+-(void) testOrderScenarioThree {
+    NSArray <NSNumber *> *result = [PHAssetsService getAssetsForFetchResult:scenarioAssets startIndex:0 endIndex:2 assetDisplayStartToEnd:NO andAssetDisplayBottomUp:NO];
+    
+    XCTAssertEqual(result.count, 3);
+    XCTAssertEqual([result[0] intValue], 2012);
+    XCTAssertEqual([result[1] intValue], 2013);
+    XCTAssertEqual([result[2] intValue], 2014);
+    //scrolling up will load
+    result = [PHAssetsService getAssetsForFetchResult:scenarioAssets startIndex:3 endIndex:5 assetDisplayStartToEnd:NO andAssetDisplayBottomUp:YES];
+    XCTAssertEqual(result.count, 2);
+    XCTAssertEqual([result[0] intValue], 2015);
+    XCTAssertEqual([result[1] intValue], 2016);
+}
+
+-(void) testOrderScenarioFour {
+    NSArray <NSNumber *> *result = [PHAssetsService getAssetsForFetchResult:scenarioAssets startIndex:0 endIndex:2 assetDisplayStartToEnd:YES andAssetDisplayBottomUp:NO];
+    
+    XCTAssertEqual(result.count, 3);
+    XCTAssertEqual([result[0] intValue], 2016);
+    XCTAssertEqual([result[1] intValue], 2015);
+    XCTAssertEqual([result[2] intValue], 2014);
+    //scrolling up will load
+    result = [PHAssetsService getAssetsForFetchResult:scenarioAssets startIndex:3 endIndex:5 assetDisplayStartToEnd:NO andAssetDisplayBottomUp:YES];
+    XCTAssertEqual(result.count, 2);
+    XCTAssertEqual([result[0] intValue], 2013);
+    XCTAssertEqual([result[1] intValue], 2012);
+}
+
+@end


### PR DESCRIPTION
reversing the getAsset-response. Also moved to using more advanced enumeration. Early implementation.

If we have a collection with 20 assets
this:
`
getAssets({
 startIndex : 0,
 endIndex : 10,
 reverse : true
})
`
will give you indices 10-20 in reverse order.
first asset will be index 20 and so on. 
