### PR TITLE
Update PHFetchOptionsService.m

### DIFF
--- a/ios/RNPhotosFramework/PHAssetsService.m
+++ b/ios/RNPhotosFramework/PHAssetsService.m
@@ -100,7 +100,7 @@
     if(assetCount != 0) {
         if(reverseIndices) {
             int originalStartIndex = startIndex;
-            startIndex = assetCount - endIndex;
+            startIndex = (assetCount - endIndex) - 1;
             endIndex = assetCount - originalStartIndex;
         }
         if(startIndex < 0) {
@@ -110,10 +110,10 @@
             endIndex = 0;
         }
         if(startIndex >= assetCount) {
-            startIndex = assetCount -1;
+            startIndex = assetCount;
         }
         if(endIndex >= assetCount) {
-            endIndex = assetCount -1;
+            endIndex = assetCount;
         }
         NSIndexSet *indexSet = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(startIndex, endIndex - startIndex)];
         NSEnumerationOptions enumerationOptions = reverseIndices ? NSEnumerationConcurrent : NSEnumerationReverse;

--- a/ios/RNPhotosFramework/PHFetchOptionsService.m
+++ b/ios/RNPhotosFramework/PHFetchOptionsService.m
@@ -26,9 +26,6 @@
     NSDictionary *params = [RCTConvert NSDictionary:outerParams[@"fetchOptions"]];
     PHFetchOptions *options = [[PHFetchOptions alloc] init];
     options = [self getCommonFetchOptionsFromParams:params andFetchOptions:options];
-    if(options.sortDescriptors == nil || options.sortDescriptors.count == 0) {
-        options.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"creationDate" ascending:NO]];
-    }
     return options;
 }
 


### PR DESCRIPTION
In order to reverse by original "native" sort, this default sortDescriptor must not be set. 

Are there any particular reasons the sortDescriptors was set to creationDate ascending:no by default?