### PR TITLE
Fixed sorting of assets.

### DIFF
--- a/ios/RNPhotosFramework/PHAssetsService.h
+++ b/ios/RNPhotosFramework/PHAssetsService.h
@@ -3,7 +3,7 @@
 @interface PHAssetsService : NSObject
 +(PHFetchResult<PHAsset *> *) getAssetsForParams:(NSDictionary *)params;
 +(NSArray<NSDictionary *> *) assetsArrayToUriArray:(NSArray<PHAsset *> *)assetsArray andIncludeMetaData:(BOOL)includeMetaData;
-+(NSMutableArray<PHAsset *> *) getAssetsForFetchResult:(PHFetchResult *)assetsFetchResult startIndex:(int)startIndex endIndex:(int)endIndex andReverseIndices:(BOOL)reverseIndices;
++(NSMutableArray<PHAsset *> *) getAssetsForFetchResult:(PHFetchResult *)assetsFetchResult startIndex:(int)startIndex endIndex:(int)endIndex assetDisplayStartToEnd:(BOOL)assetDisplayStartToEnd andAssetDisplayTopDown:(BOOL)assetDisplayTopDown;
 +(PHFetchResult<PHAsset *> *) getAssetsFromArrayOfLocalIdentifiers:(NSArray<NSString *> *)arrayWithLocalIdentifiers;
 +(NSMutableDictionary *)extendAssetDicWithAssetMetaData:(NSMutableDictionary *)dictToExtend andPHAsset:(PHAsset *)asset;
 +(void)deleteAssets:(NSArray<PHAsset *> *)assetsToDelete andCompleteBLock:(nullable void(^)(BOOL success, NSError *__nullable error, NSArray<NSString *> * localIdentifiers))completeBlock;

--- a/ios/RNPhotosFramework/PHAssetsService.h
+++ b/ios/RNPhotosFramework/PHAssetsService.h
@@ -3,7 +3,7 @@
 @interface PHAssetsService : NSObject
 +(PHFetchResult<PHAsset *> *) getAssetsForParams:(NSDictionary *)params;
 +(NSArray<NSDictionary *> *) assetsArrayToUriArray:(NSArray<PHAsset *> *)assetsArray andIncludeMetaData:(BOOL)includeMetaData;
-+(NSMutableArray<PHAsset *> *) getAssetsForFetchResult:(PHFetchResult *)assetsFetchResult startIndex:(int)startIndex endIndex:(int)endIndex assetDisplayStartToEnd:(BOOL)assetDisplayStartToEnd andAssetDisplayTopDown:(BOOL)assetDisplayTopDown;
++(NSMutableArray<PHAsset *> *) getAssetsForFetchResult:(PHFetchResult *)assetsFetchResult startIndex:(int)startIndex endIndex:(int)endIndex assetDisplayStartToEnd:(BOOL)assetDisplayStartToEnd andAssetDisplayBottomUp:(BOOL)assetDisplayBottomUp;
 +(PHFetchResult<PHAsset *> *) getAssetsFromArrayOfLocalIdentifiers:(NSArray<NSString *> *)arrayWithLocalIdentifiers;
 +(NSMutableDictionary *)extendAssetDicWithAssetMetaData:(NSMutableDictionary *)dictToExtend andPHAsset:(PHAsset *)asset;
 +(void)deleteAssets:(NSArray<PHAsset *> *)assetsToDelete andCompleteBLock:(nullable void(^)(BOOL success, NSError *__nullable error, NSArray<NSString *> * localIdentifiers))completeBlock;

--- a/ios/RNPhotosFramework/PHAssetsService.m
+++ b/ios/RNPhotosFramework/PHAssetsService.m
@@ -120,7 +120,7 @@
         }
         NSIndexSet *indexSet = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(startIndex, endIndex - startIndex)];
         // display assets from the bottom to top of page if assetDisplayBottomUp is true
-        NSEnumerationOptions enumerationOptions = assetDisplayBottomUp ? NSEnumerationReverse : NSEnumerationConcurrent;
+        NSEnumerationOptions enumerationOptions = assetDisplayBottomUp ? NSEnumerationConcurrent : NSEnumerationReverse;
         [assetsFetchResult enumerateObjectsAtIndexes:indexSet options:enumerationOptions usingBlock:^(PHAsset *asset, NSUInteger idx, BOOL * _Nonnull stop) {
             [assets addObject:asset];
         }];

--- a/ios/RNPhotosFramework/PHAssetsService.m
+++ b/ios/RNPhotosFramework/PHAssetsService.m
@@ -93,20 +93,16 @@
     return dictToExtend;
 }
 
-+(NSMutableArray<PHAsset *> *) getAssetsForFetchResult:(PHFetchResult *)assetsFetchResult startIndex:(int)startIndex endIndex:(int)endIndex andReverseIndices:(BOOL)reverseIndices {
-    
++(NSMutableArray<PHAsset *> *) getAssetsForFetchResult:(PHFetchResult *)assetsFetchResult startIndex:(int)startIndex endIndex:(int)endIndex assetDisplayStartToEnd:(BOOL)assetDisplayStartToEnd andAssetDisplayTopDown:(BOOL)assetDisplayTopDown {
     NSMutableArray<PHAsset *> *assets = [NSMutableArray new];
     int assetCount = assetsFetchResult.count;
     if(assetCount != 0) {
         int originalStartIndex = startIndex;
         int originalEndIndex = endIndex;
-
-        // load most recent assets from library first by default
         startIndex = (assetCount - endIndex) - 1;
         endIndex = assetCount - originalStartIndex;
-        
-        // load oldest assets from library first if reverseIndices is true
-        if(reverseIndices) {
+        // load oldest assets from library first if assetDisplayStartToEnd is true
+        if(assetDisplayStartToEnd) {
             startIndex = originalStartIndex;
             endIndex = originalEndIndex;
         }
@@ -123,7 +119,8 @@
             endIndex = assetCount;
         }
         NSIndexSet *indexSet = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(startIndex, endIndex - startIndex)];
-        NSEnumerationOptions enumerationOptions = reverseIndices ? NSEnumerationConcurrent : NSEnumerationReverse;
+        // display assets from the top to bottom of page if assetDisplayTopDown is true
+        NSEnumerationOptions enumerationOptions = assetDisplayTopDown ? NSEnumerationConcurrent : NSEnumerationReverse;
         [assetsFetchResult enumerateObjectsAtIndexes:indexSet options:enumerationOptions usingBlock:^(PHAsset *asset, NSUInteger idx, BOOL * _Nonnull stop) {
             [assets addObject:asset];
         }];

--- a/ios/RNPhotosFramework/PHAssetsService.m
+++ b/ios/RNPhotosFramework/PHAssetsService.m
@@ -98,10 +98,17 @@
     NSMutableArray<PHAsset *> *assets = [NSMutableArray new];
     int assetCount = assetsFetchResult.count;
     if(assetCount != 0) {
+        int originalStartIndex = startIndex;
+        int originalEndIndex = endIndex;
+
+        // load most recent assets from library first by default
+        startIndex = (assetCount - endIndex) - 1;
+        endIndex = assetCount - originalStartIndex;
+        
+        // load oldest assets from library first if reverseIndices is true
         if(reverseIndices) {
-            int originalStartIndex = startIndex;
-            startIndex = (assetCount - endIndex) - 1;
-            endIndex = assetCount - originalStartIndex;
+            startIndex = originalStartIndex;
+            endIndex = originalEndIndex;
         }
         if(startIndex < 0) {
             startIndex = 0;
@@ -116,7 +123,7 @@
             endIndex = assetCount;
         }
         NSIndexSet *indexSet = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(startIndex, endIndex - startIndex)];
-        NSEnumerationOptions enumerationOptions = reverseIndices ? NSEnumerationReverse : NSEnumerationConcurrent;
+        NSEnumerationOptions enumerationOptions = reverseIndices ? NSEnumerationConcurrent : NSEnumerationReverse;
         [assetsFetchResult enumerateObjectsAtIndexes:indexSet options:enumerationOptions usingBlock:^(PHAsset *asset, NSUInteger idx, BOOL * _Nonnull stop) {
             [assets addObject:asset];
         }];

--- a/ios/RNPhotosFramework/PHAssetsService.m
+++ b/ios/RNPhotosFramework/PHAssetsService.m
@@ -119,7 +119,7 @@
             endIndex = assetCount;
         }
         NSIndexSet *indexSet = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(startIndex, endIndex - startIndex)];
-        // display assets from the top to bottom of page if assetDisplayBottomUp is true
+        // display assets from the bottom to top of page if assetDisplayBottomUp is true
         NSEnumerationOptions enumerationOptions = assetDisplayBottomUp ? NSEnumerationReverse : NSEnumerationConcurrent;
         [assetsFetchResult enumerateObjectsAtIndexes:indexSet options:enumerationOptions usingBlock:^(PHAsset *asset, NSUInteger idx, BOOL * _Nonnull stop) {
             [assets addObject:asset];

--- a/ios/RNPhotosFramework/PHAssetsService.m
+++ b/ios/RNPhotosFramework/PHAssetsService.m
@@ -93,7 +93,7 @@
     return dictToExtend;
 }
 
-+(NSMutableArray<PHAsset *> *) getAssetsForFetchResult:(PHFetchResult *)assetsFetchResult startIndex:(int)startIndex endIndex:(int)endIndex assetDisplayStartToEnd:(BOOL)assetDisplayStartToEnd andAssetDisplayTopDown:(BOOL)assetDisplayTopDown {
++(NSMutableArray<PHAsset *> *) getAssetsForFetchResult:(PHFetchResult *)assetsFetchResult startIndex:(int)startIndex endIndex:(int)endIndex assetDisplayStartToEnd:(BOOL)assetDisplayStartToEnd andAssetDisplayBottomUp:(BOOL)assetDisplayBottomUp {
     NSMutableArray<PHAsset *> *assets = [NSMutableArray new];
     int assetCount = assetsFetchResult.count;
     if(assetCount != 0) {
@@ -119,8 +119,8 @@
             endIndex = assetCount;
         }
         NSIndexSet *indexSet = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(startIndex, endIndex - startIndex)];
-        // display assets from the top to bottom of page if assetDisplayTopDown is true
-        NSEnumerationOptions enumerationOptions = assetDisplayTopDown ? NSEnumerationConcurrent : NSEnumerationReverse;
+        // display assets from the top to bottom of page if assetDisplayBottomUp is true
+        NSEnumerationOptions enumerationOptions = assetDisplayBottomUp ? NSEnumerationReverse : NSEnumerationConcurrent;
         [assetsFetchResult enumerateObjectsAtIndexes:indexSet options:enumerationOptions usingBlock:^(PHAsset *asset, NSUInteger idx, BOOL * _Nonnull stop) {
             [assets addObject:asset];
         }];

--- a/ios/RNPhotosFramework/PHCollectionService.m
+++ b/ios/RNPhotosFramework/PHCollectionService.m
@@ -170,8 +170,9 @@ static id ObjectOrNull(id object)
                 }
                 
                 if(numberOfPreviewAssets > 0) {
-                   BOOL reverseIndices = [RCTConvert BOOL:assetFetchParams[@"reverse"]];
-                   NSArray<NSDictionary *> *previewAssets = [PHAssetsService assetsArrayToUriArray:[PHAssetsService getAssetsForFetchResult:assets startIndex:0 endIndex:(numberOfPreviewAssets-1) andReverseIndices:reverseIndices] andIncludeMetaData:NO];
+                    BOOL assetDisplayStartToEnd = [RCTConvert BOOL:assetFetchParams[@"assetDisplayStartToEnd"]];
+                    BOOL assetDisplayTopDown = [RCTConvert BOOL:assetFetchParams[@"assetDisplayTopDown"]];
+                    NSArray<NSDictionary *> *previewAssets = [PHAssetsService assetsArrayToUriArray:[PHAssetsService getAssetsForFetchResult:assets startIndex:0 endIndex:(numberOfPreviewAssets-1) assetDisplayStartToEnd:assetDisplayStartToEnd andAssetDisplayTopDown:assetDisplayTopDown] andIncludeMetaData:NO];
                     [albumDictionary setObject:previewAssets forKey:@"previewAssets"];
                 }
                 

--- a/ios/RNPhotosFramework/PHCollectionService.m
+++ b/ios/RNPhotosFramework/PHCollectionService.m
@@ -171,8 +171,8 @@ static id ObjectOrNull(id object)
                 
                 if(numberOfPreviewAssets > 0) {
                     BOOL assetDisplayStartToEnd = [RCTConvert BOOL:assetFetchParams[@"assetDisplayStartToEnd"]];
-                    BOOL assetDisplayTopDown = [RCTConvert BOOL:assetFetchParams[@"assetDisplayTopDown"]];
-                    NSArray<NSDictionary *> *previewAssets = [PHAssetsService assetsArrayToUriArray:[PHAssetsService getAssetsForFetchResult:assets startIndex:0 endIndex:(numberOfPreviewAssets-1) assetDisplayStartToEnd:assetDisplayStartToEnd andAssetDisplayTopDown:assetDisplayTopDown] andIncludeMetaData:NO];
+                    BOOL assetDisplayBottomUp = [RCTConvert BOOL:assetFetchParams[@"assetDisplayBottomUp"]];
+                    NSArray<NSDictionary *> *previewAssets = [PHAssetsService assetsArrayToUriArray:[PHAssetsService getAssetsForFetchResult:assets startIndex:0 endIndex:(numberOfPreviewAssets-1) assetDisplayStartToEnd:assetDisplayStartToEnd andAssetDisplayBottomUp:assetDisplayBottomUp] andIncludeMetaData:NO];
                     [albumDictionary setObject:previewAssets forKey:@"previewAssets"];
                 }
                 

--- a/ios/RNPhotosFramework/RCTCameraRollRNPhotosFrameworkManager.m
+++ b/ios/RNPhotosFramework/RCTCameraRollRNPhotosFrameworkManager.m
@@ -71,8 +71,9 @@ RCT_EXPORT_METHOD(getAssets:(NSDictionary *)params
     int startIndex = [RCTConvert int:startIndexParam];
     int endIndex = endIndexParam != nil ? [RCTConvert int:endIndexParam] : (assetsFetchResult.count -1);
     
-    BOOL reverseIndices = [RCTConvert BOOL:params[@"reverse"]];
-    NSArray<PHAsset *> *assets = [PHAssetsService getAssetsForFetchResult:assetsFetchResult startIndex:startIndex endIndex:endIndex andReverseIndices:reverseIndices];
+    BOOL assetDisplayStartToEnd = [RCTConvert BOOL:params[@"assetDisplayStartToEnd"]];
+    BOOL assetDisplayTopDown = [RCTConvert BOOL:params[@"assetDisplayTopDown"]];
+    NSArray<PHAsset *> *assets = [PHAssetsService getAssetsForFetchResult:assetsFetchResult startIndex:startIndex endIndex:endIndex assetDisplayStartToEnd:assetDisplayStartToEnd andAssetDisplayTopDown:assetDisplayTopDown];
     [self prepareAssetsForDisplayWithParams:params andAssets:assets];
     NSInteger assetCount = assetsFetchResult.count;
     BOOL includesLastAsset = assetCount == 0 || endIndex >= (assetCount -1);

--- a/ios/RNPhotosFramework/RCTCameraRollRNPhotosFrameworkManager.m
+++ b/ios/RNPhotosFramework/RCTCameraRollRNPhotosFrameworkManager.m
@@ -72,8 +72,8 @@ RCT_EXPORT_METHOD(getAssets:(NSDictionary *)params
     int endIndex = endIndexParam != nil ? [RCTConvert int:endIndexParam] : (assetsFetchResult.count -1);
     
     BOOL assetDisplayStartToEnd = [RCTConvert BOOL:params[@"assetDisplayStartToEnd"]];
-    BOOL assetDisplayTopDown = [RCTConvert BOOL:params[@"assetDisplayTopDown"]];
-    NSArray<PHAsset *> *assets = [PHAssetsService getAssetsForFetchResult:assetsFetchResult startIndex:startIndex endIndex:endIndex assetDisplayStartToEnd:assetDisplayStartToEnd andAssetDisplayTopDown:assetDisplayTopDown];
+    BOOL assetDisplayBottomUp = [RCTConvert BOOL:params[@"assetDisplayBottomUp"]];
+    NSArray<PHAsset *> *assets = [PHAssetsService getAssetsForFetchResult:assetsFetchResult startIndex:startIndex endIndex:endIndex assetDisplayStartToEnd:assetDisplayStartToEnd andAssetDisplayBottomUp:assetDisplayBottomUp];
     [self prepareAssetsForDisplayWithParams:params andAssets:assets];
     NSInteger assetCount = assetsFetchResult.count;
     BOOL includesLastAsset = assetCount == 0 || endIndex >= (assetCount -1);


### PR DESCRIPTION
This fix should do the trick!  By default, assets will be loaded from newest to oldest.  If the reverse prop is true, oldest assets will be loaded first.  I've tested in my app and all is running smoothly!

Now, we need to decide if the "reverse" prop is descriptive enough.  Perhaps renaming this prop to "reverseAssetSort" would be more descriptive since this prop reverses the sort on the assets being loaded?  Let me know your thoughts and suggestions.  Glad this is working as expected!