### PR TITLE
Updated indexRangeLength and assetDisplayBottomUp

### DIFF
--- a/ios/RNPhotosFramework/PHAssetsService.m
+++ b/ios/RNPhotosFramework/PHAssetsService.m
@@ -118,9 +118,19 @@
         if(endIndex >= assetCount) {
             endIndex = assetCount;
         }
-        NSIndexSet *indexSet = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(startIndex, endIndex - startIndex)];
+        int indexRangeLength = endIndex - startIndex;
+        // adjust range length calculation if original and active index are 0
+        if(originalStartIndex == 0 && startIndex == 0){
+            indexRangeLength = (endIndex - startIndex) + 1;
+        }
+        if(indexRangeLength >= assetCount){
+            indexRangeLength = assetCount;
+        }
+        NSIndexSet *indexSet = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(startIndex, indexRangeLength)];
+        NSEnumerationOptions enumerationOptionsStartToEnd = assetDisplayBottomUp ? NSEnumerationReverse : NSEnumerationConcurrent;
+        NSEnumerationOptions enumerationOptionsEndToStart = assetDisplayBottomUp ? NSEnumerationConcurrent : NSEnumerationReverse;
         // display assets from the bottom to top of page if assetDisplayBottomUp is true
-        NSEnumerationOptions enumerationOptions = assetDisplayBottomUp ? NSEnumerationConcurrent : NSEnumerationReverse;
+        NSEnumerationOptions enumerationOptions = assetDisplayStartToEnd ? enumerationOptionsStartToEnd : enumerationOptionsEndToStart;
         [assetsFetchResult enumerateObjectsAtIndexes:indexSet options:enumerationOptions usingBlock:^(PHAsset *asset, NSUInteger idx, BOOL * _Nonnull stop) {
             [assets addObject:asset];
         }];


### PR DESCRIPTION
The indexSet was not calculating the correct range length when sorting from oldest to newest when starting at index 0.  Since the range was being calculated by endIndex - startIndex, the range was off by 1 since the actual range of assets for 0-2 is 3 and not 2. I created an if to account for this if the originalStartIndex and startIndex are both 0.

I also adjusted the way the assets are displayed from the bottom to top of page depending on whether assets should be loaded from start to end.

I've tested against the test scenarios and all is working.