### PR TITLE
Fix crash due to not defined enum bit flag option

### DIFF
--- a/ios/RNPhotosFramework/RNPFHelpers.m
+++ b/ios/RNPhotosFramework/RNPFHelpers.m
@@ -51,9 +51,11 @@
     NSMutableArray * nsOptions = [[NSMutableArray alloc] init];
         for (NSUInteger i=0; i < bitSize; i++) {
         NSUInteger enumBitValueToCheck = 1UL << i;
-        if (option & enumBitValueToCheck) {
-            [nsOptions addObject:[dict objectForKey:@(enumBitValueToCheck)]];
-            
+        if ((option & enumBitValueToCheck)) {
+            NSObject *option = dict[@(enumBitValueToCheck)];
+            if (option) {
+                [nsOptions addObject:option];
+            }
         }
     }
     


### PR DESCRIPTION
We observed crashes like these for two users:

```
Exception name=RCTFatalException: Exception '*** -[__NSArrayM insertObject:atIndex:]: object cannot be nil' was thrown while invoking getAssets on target CameraRollRNPhotosFrameworkManager with params (
        {
        endIndex = 60;
        fetchOptions =         {
            mediaTypes =             (
                image
            );
            sortDescriptors =             (
                                {
                    ascending = 0;
                    key = creationDate;
                }
            );
        };
        includeMetaData = 1;
        prepareForSizeDisplay =         {
            height = "131.3333333333333";
            width = "131.3333333333333";
        };
        startIndex = 0;
    },
    164,
    165
)

...
```

After much digging through the code I am quite certain the problem is in `RNPFHelpers. nsOptionsToArray`. iOS 10.2 introduced `PHAssetMediaSubtypePhotoDepthEffect` (for iPhone 7+ and these two users both have it) which is not defined in `RCTConvert+RNPhotosFramework.m`. https://developer.apple.com/reference/photos/phassetmediasubtype?changes=latest_minor&language=objc

This PR just fixes testing that the option has a value, so that this doesn't crash for this one nor when when Apple adds new flags. 

It doesn't add definition for `PHAssetMediaSubtypePhotoDepthEffect` because it is specified under "Type Properties" where the others are specified under "Constants" and I don't know what the difference is, plus I don't know if defining it would means that the library depends on iOS 10.2? I guess not but maybe just the most recent version of the SDK...
