### PR TITLE
Check selectors not supported in iOS 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ for fetchOptions. You can also read Apple's documentation around [PHFetchOptions
 | :------------ |:---------------:| :---------------:| :-----|
 | mediaTypes (Only for `getAssets`) | - | `array<string>` | Defines what mediaType the asset should be. Array combined with OR-operator. e.g. ['image', 'video'] will return both photos and videos. Converted in Native to PHAssetMediaType. Accepted values: `image`, `video`, `audio`, `unknown` |
 | mediaSubTypes (Only for `getAssets`) | - | `array<string>` | Defines what subtype the asset should be. Array combined with OR-operator. e.g. ['photoPanorama', 'photoHDR'] will return both panorama and HDR-assets. Converted in Native to PHAssetMediaSubtype. Accepted enum-values: `none`, `photoPanorama`, `photoHDR`, `photoScreenshot`, `photoLive`, `videoStreamed`, `videoHighFrameRate`, `videoTimeLapse` (mediaTypes and mediaSubTypes are combined with AND-operator) |
-| sourceTypes (Only for `getAssets`) | - | `array<string>` | Defines where the asset should come from originally. Array combined with OR-operator. Converted in Native to PHAssetSourceType. Accepted enum-values: `none`, `userLibrary`, `cloudShared`, `itunesSynced`. |
+| sourceTypes (Only for `getAssets`) | - | `array<string>` | Defines where the asset should come from originally. Array combined with OR-operator. Converted in Native to PHAssetSourceType. Accepted enum-values: `none`, `userLibrary`, `cloudShared`, `itunesSynced`. (not supported and ignored in iOS 8) |
 | includeHiddenAssets | false | `boolean` | A Boolean value that determines whether the fetch result includes assets marked as hidden. |
 | includeAllBurstAssets | false | `boolean` | A Boolean value that determines whether the fetch result includes all assets from burst photo sequences. |
 | fetchLimit | 0 | `number` | The maximum number of objects to include in the fetch result. Remember to not use this in the wrong way combined with startIndex and endIndex. 0 means unlimited. |
@@ -131,6 +131,8 @@ modificationDate : 1466766146
 sourceType : "userLibrary"
 uri : "pk://3D5E6260-2B63-472E-A38A-3B543E936E8C/L0/001"
 ~~~~
+
+(`sourceType` is not supported in iOS 8)
 
 # Retrieving albums and enumerating their assets:
 ~~~~

--- a/ios/RNPhotosFramework/PHAssetsService.m
+++ b/ios/RNPhotosFramework/PHAssetsService.m
@@ -104,7 +104,10 @@
     [dictToExtend setObject:[RNPFHelpers nsOptionsToArray:[asset mediaSubtypes] andBitSize:32 andReversedEnumDict:[RCTConvert PHAssetMediaSubtypeValuesReversed]] forKey:@"mediaSubTypes"];
     [dictToExtend setObject:@([asset isFavorite]) forKey:@"isFavorite"];
     [dictToExtend setObject:@([asset isHidden]) forKey:@"isHidden"];
-    [dictToExtend setObject:[RNPFHelpers nsOptionsToValue:[asset sourceType] andBitSize:32 andReversedEnumDict:[RCTConvert PHAssetSourceTypeValuesReversed]] forKey:@"sourceType"];
+    if ([asset respondsToSelector:@selector(sourceType)]) {
+        // not available in iOS 8
+        [dictToExtend setObject:[RNPFHelpers nsOptionsToValue:[asset sourceType] andBitSize:32 andReversedEnumDict:[RCTConvert PHAssetSourceTypeValuesReversed]] forKey:@"sourceType"];
+    }
     NSString *burstIdentifier = [asset burstIdentifier];
     if(burstIdentifier != nil) {
         [dictToExtend setObject:burstIdentifier forKey:@"burstIdentifier"];

--- a/ios/RNPhotosFramework/PHFetchOptionsService.m
+++ b/ios/RNPhotosFramework/PHFetchOptionsService.m
@@ -5,7 +5,10 @@
 @implementation PHFetchOptionsService
 
 +(PHFetchOptions *)getCommonFetchOptionsFromParams:(NSDictionary *)params andFetchOptions:(PHFetchOptions *)options {
-    options.includeAssetSourceTypes = [RCTConvert PHAssetSourceTypes:params[@"sourceTypes"]];
+    if ([options respondsToSelector:@selector(includeAssetSourceTypes)]) {
+        // not available in iOS 8
+        options.includeAssetSourceTypes = [RCTConvert PHAssetSourceTypes:params[@"sourceTypes"]];
+    }
     options.includeHiddenAssets = [RCTConvert BOOL:params[@"includeHiddenAssets"]];
     options.includeAllBurstAssets = [RCTConvert BOOL:params[@"includeAllBurstAssets"]];
     options.fetchLimit = [RCTConvert int:params[@"fetchLimit"]];


### PR DESCRIPTION
We can see this crash for iOS 8.4 both on device and in simulator:

```
Exception name=RCTFatalException: 
Exception '-[PHFetchOptions setIncludeAssetSourceTypes:]: unrecognized selector sent to instance 0x1702c08c0' was thrown while invoking getAssets on target 
CameraRollRNPhotosFrameworkManager with params (... ) ...
```

This PR checks that two specific selectors that we saw crashes for are available, in iOS 8 that will no be the case. I manually tested that the `sourceType` option still works in iOS 10 Simulator.

I'm not exactly sure what the implications of this option not supported in iOS 8 are. 8.4 Simulator Photos / Settings app crashed when I tried to enable iCloud photo library (probably because the apple id has been used with later iOS versions), so I could not test that. At least it isn't crashing anymore and we could get the standard Simulator photos + manually added ones via the library.