### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,3 +589,11 @@ const unsubscribeFunc = album.onChange((changeDetails, update) => {
 });
 ~~~~
 The update-function will apply the changes to your collection.
+
+Call the unsubscribeFunc in order to unsubscribe from the onChange event.
+~~~~
+componentDidUnmount: function () {
+  unsubscribeFunc();
+  album.stopTracking();
+}
+~~~~


### PR DESCRIPTION
Added clarification regarding how to properly unsubscribe to an onChange event.

It took me a while to figure out how to do properly unsubscribe to the onChange event since I was confused with how to properly implement album.stopTracking(), so I decided to add clarification in the README docs.