### PR TITLE
Fix crash when calling metadata on new Portrait mode

### DIFF
--- a/ios/RNPhotosFramework/RCTConvert+RNPhotosFramework.m
+++ b/ios/RNPhotosFramework/RCTConvert+RNPhotosFramework.m
@@ -65,7 +65,7 @@ RCT_ENUM_CONVERTER_WITH_REVERSED(PHAssetMediaSubtype, (@{
                                            @"videoStreamed": @(PHAssetMediaSubtypeVideoStreamed),
                                            @"videoHighFrameRate": @(PHAssetMediaSubtypeVideoHighFrameRate),
                                            @"videoTimeLapse": @(PHAssetMediaSubtypeVideoTimelapse),
-                                           
+                                           @"photoDepthEffect": @(PHAssetMediaSubtypePhotoDepthEffect),
                                            }), PHAssetMediaSubtypeNone, integerValue)
 
 


### PR DESCRIPTION
A new image subtype corresponding to the new Portrait mode available on the iPhone 7 Plus has been added to the framework.

The following line would crash when accessing metadata on assets which such a subtype:

```objc
[dictToExtend setObject:[RNPFHelpers nsOptionsToArray:[asset mediaSubtypes] andBitSize:32 andReversedEnumDict:[RCTConvert PHAssetMediaSubtypeValuesReversed]]
```

(See [PHAssetsService.m#L104](https://github.com/olofd/react-native-photos-framework/blob/a042ab2169ace9d9dad6909b3e4a3d3f089a1f97/ios/RNPhotosFramework/PHAssetsService.m#L104))

Adding the new corresponding image subtype `photoDepthEffect` to the list of known media sub types did the trick.

Update: Of course I just now saw the issues #28 and #32 ...