### PR TITLE
Adds new Asset() for 'unknown' type

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -286,7 +286,7 @@ class RNPhotosFramework {
     createVideoAsset(video) {
         return this.createAssets({
             videos: [video],
-        }).then(result => result[1]);
+        }).then(result => result[0]);
     }
 
     getPostableAssets(localIdentifiers) {

--- a/src/index.js
+++ b/src/index.js
@@ -380,6 +380,8 @@ class RNPhotosFramework {
                 return new ImageAsset(nativeObj, options);
             case "video":
                 return new VideoAsset(nativeObj, options);
+            case "unknown":
+                return new Asset(nativeObj, options);
         }
     }
 


### PR DESCRIPTION
The lack of a case for unknown (or a `default` as it may be) caused my `getAssets` call to return a list with many `undefined` values. This solves my problems neatly and I have not run into any problems with it so far. 

Thanks for the amazing library.