### PR TITLE
Improve errors in saveAssetsToDisk / saveAssetToDisk

### DIFF
--- a/example/react-native-camera-roll-picker/camera-roll-picker.js
+++ b/example/react-native-camera-roll-picker/camera-roll-picker.js
@@ -151,15 +151,15 @@ class CameraRollPicker extends Component {
           }).then((result) => {
             //debugger;
           });*/
-        data.assets[0].saveAssetToDisk({ 
+        data.assets[0].saveAssetToDisk({
           fileName : 'test.png',
           dir: RNFetchBlob.fs.dirs.DocumentDir,
           ...videoOptions
         }, (e) => {
           console.log(e);
-        }).then((result) => {
+        }).then((fileUrl) => {
           console.log('finnished');
-          RNFetchBlob.fs.exists(result.fileUrl)
+          RNFetchBlob.fs.exists(fileUrl)
             .then((exist) => {
               console.log(`file ${result.fileUrl} ${exist ? '' : 'not'} exists`)
             });

--- a/ios/RNPhotosFramework/RCTImageResizer.h
+++ b/ios/RNPhotosFramework/RCTImageResizer.h
@@ -10,5 +10,5 @@
                   rotation:(float)rotation
                 outputPath:(NSString *)outputPath
                   fileName:(NSString *)fileName
-          andCompleteBLock:(void(^)(NSString *error, NSString *path))completeBlock;
+          andCompleteBLock:(void(^)(NSString *path, NSError *error))completeBlock;
 @end

--- a/src/asset.js
+++ b/src/asset.js
@@ -135,7 +135,13 @@ export default class Asset {
         }], {
                 onProgress: onProgress
             }, generateFileName).then((results) => {
-                return results[0];
+              const result = results[0];
+              if (result.success) {
+                return result.fileUrl;
+              }
+              else {
+                throw result.error;
+              }
             });
     }
 


### PR DESCRIPTION
Nice to see this project moving along!

While upgrading our native dependencies I noticed there is now support for resizing and saving assets to disk, this allows us to get rid of some own native code for that, nice! 🙏

However, I noticed that file writing errors would be silently ignored. This can happen e.g. if we specify a directory which isn't writable or doesn't exist (bugs), but also if the disk is full, which we have seen in our logs several times previously.

- Change signature of `RNPFImageResizer.createResizedImage` `completeBlock` to `(NSString *path, NSError *error)`, so it can report actual NSError objects. I changed the order of arguments to be more conventional "objective-c" (which I don't know much about, but according to http://nshipster.com/nserror/). 
- Have _not_ converted the contents of previous `NSString *error` argument, because they were not being added to the result before (I gave up while reading up on creating errors with domain/code etc.). The `success` will still be `false` in those cases, since the `path` is set to `nil`. It's a good idea to do this, but I'm happy with just file errors getting reported.
- Convert the NSError into JSON in the result `error`, (rather than `localizedDescription` as before), to be able to log/display it as needed. This is the same representation that gets returned with `reject(nil, nil, nsError)`. I recommend to do the same in `updateAssets` too but haven't changed it.
- Change `saveAssetToDisk` so the promise is either rejected with the error from native (before it was needed or resolved with the `fileUrl` (`localIdentifier` shouldn't be of interest since you are working on a single asset). Updated example to reflect this change.