### PR TITLE
Fix 'undefined asset' when using createVideoAsset

### DIFF
--- a/README.md
+++ b/README.md
@@ -636,7 +636,7 @@ Create a image-asset
   RCTCameraRollRNPhotosFrameworkManager.createVideoAsset(videoWithUriProp);
 ~~~
 Signature: album.createVideoAsset(params) : Promise<Asset>.
-Create a image-asset
+Create a video-asset
 
 ### createAssets
 ~~~js

--- a/src/index.js
+++ b/src/index.js
@@ -286,7 +286,7 @@ class RNPhotosFramework {
     createVideoAsset(video) {
         return this.createAssets({
             videos: [video],
-        }).then(result => result[1]);
+        }).then(result => result[0]);
     }
 
     getPostableAssets(localIdentifiers) {


### PR DESCRIPTION
The result of `createVideoAsset(...).then(asset =>  asset.uri)` is undefined. 

Current workaround - use `createAssets` directly and take the first item.

This PR fixes the error.